### PR TITLE
Add Firefox addon link to installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ The fact that this improves loading times is bizarre, because GitHub is a single
 
 ## Installation
 - [Chrome web store](https://chromewebstore.google.com/detail/make-github-great-again/pblbdbcpfdpmhmcmgjmggdigeakhmend)
-- Firefox support coming soon
+- [Firefox Addon](https://addons.mozilla.org/en-US/firefox/addon/make-github-great-again-jm/)
 
 [Learn more about GitHub's awful UI performance.](https://yoyo-code.com/why-is-github-ui-getting-so-much-slower/)


### PR DESCRIPTION
https://addons.mozilla.org/en-US/firefox/addon/make-github-great-again-jm/ is the link to this extension right?